### PR TITLE
cmd/scanner: Call flag.Parse() to take command line arguments

### DIFF
--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -19,6 +19,7 @@ var (
 func main() {
 	projectId := flag.String("project", "test-project", "GCP Project ID")
 	topicId := flag.String("topic", "scan-topic", "GCP PubSub Topic ID")
+	flag.Parse()
 
 	ctx := context.Background()
 


### PR DESCRIPTION
We need to call flag.Parse() to allow overriding the project and topic IDs through the command line options.