### PR TITLE
Init Commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+.PHONY: build test clean docker-up docker-down fmt vet help
+
+# Default target
+all: build test
+
+# Build the binaries
+build:
+	go build -o processor ./cmd/processor/main.go
+	go build -o scanner ./cmd/scanner/main.go
+
+# Run pkg tests
+test:
+	go test -v ./pkg/...
+
+# Clean up binaries and database
+clean:
+	rm -f processor scanner scans.db
+
+# Run with docker-compose
+docker-up: clean
+	docker compose up --build
+
+# Stop docker-compose
+docker-down:
+	docker compose down
+
+# Run end-to-end tests
+test-e2e:
+	@echo "Running E2E tests..."
+	@# Ensure pubsub emulator is running
+	@docker compose up -d pubsub
+	@# Wait for pubsub to be healthy
+	@for i in {1..10}; do curl -s http://localhost:8085 && break || sleep 1; done
+	PUBSUB_EMULATOR_HOST=localhost:8085 go test -v ./tests/e2e/...
+	@docker compose stop pubsub
+
+# Format code
+fmt:
+	go fmt ./...
+
+# Run vet
+vet:
+	go vet ./...
+
+# Show help
+help:
+	@echo "Available targets:"
+	@echo "  build       - Build the processor and scanner binaries"
+	@echo "  test        - Run all unit tests"
+	@echo "  test-e2e    - Run end-to-end tests using docker-compose"
+	@echo "  clean       - Remove binaries and scans.db"
+	@echo "  docker-up   - Build and start the environment using docker-compose"
+	@echo "  docker-down - Stop and remove docker-compose containers"
+	@echo "  fmt         - Format Go code"
+	@echo "  vet         - Run go vet"
+	@echo "  help        - Show this help message"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,68 @@ As you've heard by now, Censys scans the internet at an incredible scale. Proces
 
 The `docker-compose.yml` file sets up a toy example of a scanner. It spins up a Google Pub/Sub emulator, creates a topic and subscription, and publishes scan results to the topic. It can be run via `docker compose up`.
 
+## Solution Documentation
+
+The solution implements a data processor that consumes scan results from Google Pub/Sub and stores them in a SQLite database.
+
+### Components
+
+- **Processor**: A Go application that subscribes to `scan-sub`, unmarshals scan results (handling V1 and V2 formats), and persists them.
+- **Repository**: An abstraction for data storage, implemented using SQLite. It handles out-of-order messages by only updating records if the incoming scan has a newer timestamp.
+- **Docker Integration**: The processor is integrated into the `docker-compose.yml` environment.
+
+### Key Features
+
+- **At-least-once semantics**: Messages are acknowledged only after successful persistence in the database.
+- **Out-of-order handling**: Uses SQL `ON CONFLICT` with a `WHERE` clause to ensure only the latest scan data is kept for each unique `(ip, port, service)`.
+- **Horizontal Scaling**: The processor can be scaled by running multiple instances against the same subscription (Pub/Sub handles distribution) and a shared or partitioned database.
+- **High Throughput Optimizations**:
+    - **Concurrency**: Uses multiple goroutines for Pub/Sub message consumption and a fixed worker pool for batch processing.
+    - **Batching**: A dedicated dispatcher groups messages into batches (up to 100 messages or every 500ms) before passing them to the worker pool, significantly reducing I/O overhead.
+    - **Database Tuning**: SQLite is configured in WAL (Write-Ahead Logging) mode with `synchronous = NORMAL` for optimal write performance while maintaining safety.
+    - **Transactional Upserts**: Each batch is processed within a single database transaction.
+
+### Testing Instructions
+
+#### Makefile
+A `Makefile` is provided for common tasks:
+- `make build`: Build the `processor` and `scanner` binaries.
+- `make test`: Run all unit tests.
+- `make docker-up`: Start the full environment.
+- `make clean`: Clean up binaries and the database.
+
+#### Automated Tests
+You can run all tests using the Makefile:
+```bash
+make test
+```
+
+To run the end-to-end tests that leverage `docker-compose`:
+```bash
+make test-e2e
+```
+
+Or run the repository tests directly (requires Go and `gcc` for `go-sqlite3`):
+```bash
+go test ./pkg/repository/...
+```
+
+#### Manual Verification
+1. Start the environment:
+   ```bash
+   make docker-up
+   ```
+   (Alternatively: `docker compose up --build`)
+2. The `processor` service will start consuming messages from the `scanner` service.
+3. You can inspect the results by querying the `scans.db` file created in the project root:
+   ```bash
+   sqlite3 scans.db "SELECT * FROM scans LIMIT 10;"
+   ```
+
+---
+
+## Original Requirements
+
 Your job is to build the data processing side. It should:
 
 1. Pull scan results from the subscription `scan-sub`.

--- a/cmd/processor/Dockerfile
+++ b/cmd/processor/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.20-bullseye
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=1 GOOS=linux go build -o processor ./cmd/processor/main.go
+RUN mkdir -p /app/data
+
+CMD ["./processor"]

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -1,0 +1,158 @@
+// Package main provides the entry point for the scan processor application.
+// The processor consumes scan results from a Google Pub/Sub subscription and
+// persists them to a database using a high-throughput, concurrent architecture.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/censys/scan-takehome/pkg/repository/sqlite"
+	"github.com/censys/scan-takehome/pkg/scanning"
+	"github.com/censys/scan-takehome/pkg/service"
+)
+
+func Run(ctx context.Context, projectID, subscriptionID, dbPath string, logger *log.Logger) error {
+	repo, err := sqlite.NewSQLiteRepository(dbPath, logger)
+	if err != nil {
+		return err
+	}
+
+	svc := service.NewScanService(repo, logger)
+
+	client, err := pubsub.NewClient(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	sub := client.Subscription(subscriptionID)
+	sub.ReceiveSettings.NumGoroutines = 64
+	sub.ReceiveSettings.MaxOutstandingMessages = 1000
+
+	batchSize := 100
+	batchTimeout := 500 * time.Millisecond
+	workerPoolSize := 8
+
+	msgChan := make(chan *pubsub.Message, 1000)
+	batchChan := make(chan []*pubsub.Message, workerPoolSize)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < workerPoolSize; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for batch := range batchChan {
+				logger.Printf("Worker %d: Processing batch of %d", id, len(batch))
+				var scans []*scanning.Scan
+				for _, msg := range batch {
+					var scan scanning.Scan
+					if err := json.Unmarshal(msg.Data, &scan); err != nil {
+						logger.Printf("Worker %d: unmarshal failed: %v", id, err)
+						msg.Ack()
+						continue
+					}
+					scans = append(scans, &scan)
+				}
+
+				if len(scans) > 0 {
+					for _, s := range scans {
+						logger.Printf("Worker %d: Writing record for %s:%d (%s)", id, s.Ip, s.Port, s.Service)
+					}
+					if err := svc.ProcessScans(ctx, scans); err != nil {
+						logger.Printf("Worker %d: process failed: %v", id, err)
+						for _, m := range batch {
+							m.Nack()
+						}
+					} else {
+						for _, m := range batch {
+							m.Ack()
+						}
+					}
+				}
+			}
+		}(i)
+	}
+
+	go func() {
+		defer close(batchChan)
+		for {
+			var batch []*pubsub.Message
+			timeout := time.After(batchTimeout)
+			finished := false
+
+			for len(batch) < batchSize && !finished {
+				select {
+				case msg, ok := <-msgChan:
+					if !ok {
+						finished = true
+						break
+					}
+					batch = append(batch, msg)
+				case <-timeout:
+					finished = true
+				case <-ctx.Done():
+					finished = true
+				}
+			}
+
+			if len(batch) > 0 {
+				select {
+				case batchChan <- batch:
+				case <-ctx.Done():
+					for _, m := range batch {
+						m.Nack()
+					}
+					return
+				}
+			}
+
+			if ctx.Err() != nil {
+				return
+			}
+		}
+	}()
+
+	err = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+		select {
+		case msgChan <- msg:
+		case <-ctx.Done():
+			msg.Nack()
+		}
+	})
+
+	close(msgChan)
+	wg.Wait()
+
+	if err != nil && ctx.Err() == nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	projectID := flag.String("project", "test-project", "GCP Project ID")
+	subscriptionID := flag.String("subscription", "scan-sub", "GCP PubSub Subscription ID")
+	dbPath := flag.String("db", "scans.db", "Path to SQLite database")
+	flag.Parse()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+	logger.Printf("Starting processor for project %s, subscription %s", *projectID, *subscriptionID)
+
+	if err := Run(ctx, *projectID, *subscriptionID, *dbPath, logger); err != nil {
+		logger.Fatalf("Processor failed: %v", err)
+	}
+	logger.Println("Processor shut down gracefully")
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,22 @@ services:
         condition: service_completed_successfully
     command: PUT http://pubsub:8085/v1/projects/test-project/subscriptions/scan-sub topic=projects/test-project/topics/scan-topic --ignore-stdin 
 
+  # Runs the "processor"
+  processor:
+    depends_on:
+      mk-subscription:
+        condition: service_completed_successfully
+    environment:
+      PUBSUB_EMULATOR_HOST: pubsub:8085
+      PUBSUB_PROJECT_ID: test-project
+    build:
+      context: .
+      dockerfile: ./cmd/processor/Dockerfile
+    volumes:
+      - scan-data:/app/data
+    command: ["./processor", "-db", "/app/data/scans.db"]
+    user: "${UID}:${GID}"
+
   # Runs the "scanner"
   scanner:
     depends_on:
@@ -40,3 +56,6 @@ services:
     build:
       context: .
       dockerfile: ./cmd/scanner/Dockerfile
+
+volumes:
+  scan-data:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/censys/scan-takehome
 
 go 1.20
 
-require cloud.google.com/go/pubsub v1.33.0
+require (
+	cloud.google.com/go/pubsub v1.33.0
+	github.com/mattn/go-sqlite3 v1.14.17
+)
 
 require (
 	cloud.google.com/go v0.110.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.2.3/go.mod h1:AwSRAtLfXpU5
 github.com/googleapis/gax-go/v2 v2.11.0 h1:9V9PWXEsWnPpQhu/PeQIkS4eGzMlTLGgt80cUUI8Ki4=
 github.com/googleapis/gax-go/v2 v2.11.0/go.mod h1:DxmR61SGKkGLa2xigwuZIQpkCI2S5iydzRfb3peWZJI=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
+github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,0 +1,22 @@
+package repository
+
+import (
+	"context"
+	"time"
+)
+
+type ScanRecord struct {
+	IP          string
+	Port        uint32
+	Service     string
+	Timestamp   time.Time
+	DataVersion int
+	RawData     interface{}
+	Response    string
+}
+
+type Repository interface {
+	UpsertScan(ctx context.Context, record *ScanRecord) error
+	UpsertScans(ctx context.Context, records []*ScanRecord) error
+	GetScan(ctx context.Context, ip string, port uint32, service string) (*ScanRecord, error)
+}

--- a/pkg/repository/sqlite/sqlite.go
+++ b/pkg/repository/sqlite/sqlite.go
@@ -1,0 +1,118 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/censys/scan-takehome/pkg/repository"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type Repository struct {
+	db     *sql.DB
+	logger *log.Logger
+}
+
+func NewSQLiteRepository(dbPath string, logger *log.Logger) (repository.Repository, error) {
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite: %w", err)
+	}
+
+	// Performance tuning
+	_, err = db.Exec(`
+		PRAGMA journal_mode = WAL;
+		PRAGMA synchronous = NORMAL;
+		PRAGMA busy_timeout = 5000;
+	`)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("set pragmas: %w", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS scans (
+			ip TEXT NOT NULL,
+			port INTEGER NOT NULL,
+			service TEXT NOT NULL,
+			timestamp DATETIME NOT NULL,
+			response TEXT,
+			PRIMARY KEY (ip, port, service)
+		)
+	`)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create table: %w", err)
+	}
+
+	return &Repository{db: db, logger: logger}, nil
+}
+
+func (r *Repository) UpsertScan(ctx context.Context, record *repository.ScanRecord) error {
+	r.logger.Printf("Repository: Upserting record for %s:%d (%s)", record.IP, record.Port, record.Service)
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO scans (ip, port, service, timestamp, response)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(ip, port, service) DO UPDATE SET
+			response = excluded.response,
+			timestamp = excluded.timestamp
+		WHERE excluded.timestamp > scans.timestamp
+	`, record.IP, record.Port, record.Service, record.Timestamp, record.Response)
+
+	if err != nil {
+		return fmt.Errorf("upsert scan: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Repository) UpsertScans(ctx context.Context, records []*repository.ScanRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO scans (ip, port, service, timestamp, response)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(ip, port, service) DO UPDATE SET
+			response = excluded.response,
+			timestamp = excluded.timestamp
+		WHERE excluded.timestamp > scans.timestamp
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare upsert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, record := range records {
+		r.logger.Printf("Repository: Upserting record for %s:%d (%s)", record.IP, record.Port, record.Service)
+		_, err := stmt.ExecContext(ctx, record.IP, record.Port, record.Service, record.Timestamp, record.Response)
+		if err != nil {
+			return fmt.Errorf("exec upsert: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (r *Repository) GetScan(ctx context.Context, ip string, port uint32, service string) (*repository.ScanRecord, error) {
+	row := r.db.QueryRowContext(ctx, "SELECT ip, port, service, timestamp, response FROM scans WHERE ip = ? AND port = ? AND service = ?", ip, port, service)
+
+	var record repository.ScanRecord
+	err := row.Scan(&record.IP, &record.Port, &record.Service, &record.Timestamp, &record.Response)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &record, nil
+}

--- a/pkg/repository/sqlite/sqlite_test.go
+++ b/pkg/repository/sqlite/sqlite_test.go
@@ -1,0 +1,298 @@
+// Package sqlite_test provides unit tests for the SQLite repository implementation.
+package sqlite
+
+import (
+	"context"
+	"io"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/censys/scan-takehome/pkg/repository"
+	"github.com/censys/scan-takehome/pkg/scanning"
+)
+
+// TestSQLiteRepository_UpsertScan verifies the core idempotency and out-of-order
+// handling logic of the repository.
+func TestSQLiteRepository_UpsertScan(t *testing.T) {
+	// Use an in-memory database for fast, isolated unit testing.
+	logger := log.New(io.Discard, "", 0)
+	repo, err := NewSQLiteRepository(":memory:", logger)
+	if err != nil {
+		t.Fatalf("Failed to create repo: %v", err)
+	}
+
+	ctx := context.Background()
+	ip := "1.2.3.4"
+	port := uint32(80)
+	service := "HTTP"
+
+	// 1. Initial Insert: verify that a new record can be saved.
+	t1 := time.Now().Truncate(time.Second)
+	rec1 := &repository.ScanRecord{
+		IP:          ip,
+		Port:        port,
+		Service:     service,
+		Timestamp:   t1,
+		DataVersion: int(scanning.V2),
+		RawData:     &scanning.V2Data{ResponseStr: "first"},
+		Response:    "first",
+	}
+
+	if err := repo.UpsertScan(ctx, rec1); err != nil {
+		t.Fatalf("Upsert failed: %v", err)
+	}
+
+	got, err := repo.GetScan(ctx, ip, port, service)
+	if err != nil {
+		t.Fatalf("GetScan failed: %v", err)
+	}
+	if got.Response != "first" {
+		t.Errorf("Expected first, got %s", got.Response)
+	}
+
+	// 2. Update with newer timestamp: verify that existing records are updated
+	// when newer information arrives.
+	t2 := t1.Add(time.Hour)
+	rec2 := &repository.ScanRecord{
+		IP:          ip,
+		Port:        port,
+		Service:     service,
+		Timestamp:   t2,
+		DataVersion: int(scanning.V2),
+		RawData:     &scanning.V2Data{ResponseStr: "second"},
+		Response:    "second",
+	}
+
+	if err := repo.UpsertScan(ctx, rec2); err != nil {
+		t.Fatalf("Upsert failed: %v", err)
+	}
+
+	got, err = repo.GetScan(ctx, ip, port, service)
+	if err != nil {
+		t.Fatalf("GetScan failed: %v", err)
+	}
+	if got.Response != "second" {
+		t.Errorf("Expected second, got %s", got.Response)
+	}
+
+	// 3. Try to update with older timestamp: verify that late-arriving (out-of-order)
+	// data does NOT overwrite newer data.
+	t3 := t1.Add(-time.Hour)
+	rec3 := &repository.ScanRecord{
+		IP:          ip,
+		Port:        port,
+		Service:     service,
+		Timestamp:   t3,
+		DataVersion: int(scanning.V2),
+		RawData:     &scanning.V2Data{ResponseStr: "third (old)"},
+		Response:    "third (old)",
+	}
+
+	if err := repo.UpsertScan(ctx, rec3); err != nil {
+		t.Fatalf("Upsert failed: %v", err)
+	}
+
+	got, err = repo.GetScan(ctx, ip, port, service)
+	if err != nil {
+		t.Fatalf("GetScan failed: %v", err)
+	}
+	if got.Response != "second" {
+		t.Errorf("Expected second to remain, got %s", got.Response)
+	}
+	if !got.Timestamp.Equal(t2) {
+		t.Errorf("Expected timestamp %v, got %v", t2, got.Timestamp)
+	}
+
+	// 4. Extreme out-of-order (24 hours old): explicitly test the case mentioned
+	// in the problem description.
+	t4 := t2.Add(-24 * time.Hour)
+	rec4 := &repository.ScanRecord{
+		IP:          ip,
+		Port:        port,
+		Service:     service,
+		Timestamp:   t4,
+		DataVersion: int(scanning.V2),
+		RawData:     &scanning.V2Data{ResponseStr: "extreme old"},
+		Response:    "extreme old",
+	}
+
+	if err := repo.UpsertScan(ctx, rec4); err != nil {
+		t.Fatalf("Upsert failed: %v", err)
+	}
+
+	got, err = repo.GetScan(ctx, ip, port, service)
+	if err != nil {
+		t.Fatalf("GetScan failed: %v", err)
+	}
+	if got.Response != "second" {
+		t.Errorf("Expected second to remain after 24h old scan, got %s", got.Response)
+	}
+	if !got.Timestamp.Equal(t2) {
+		t.Errorf("Expected timestamp %v to remain, got %v", t2, got.Timestamp)
+	}
+}
+
+// TestSQLiteRepository_ErrorHandling ensures that errors (like a closed DB)
+// are correctly propagated to the caller.
+func TestSQLiteRepository_ErrorHandling(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	repo, err := NewSQLiteRepository(":memory:", logger)
+	if err != nil {
+		t.Fatalf("Failed to create repo: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Intentionally close the database to trigger errors.
+	sqliteRepo := repo.(*Repository)
+	sqliteRepo.db.Close()
+
+	rec := &repository.ScanRecord{
+		IP:          "1.1.1.1",
+		Port:        80,
+		Service:     "HTTP",
+		Timestamp:   time.Now(),
+		DataVersion: int(scanning.V2),
+		RawData:     &scanning.V2Data{ResponseStr: "test"},
+	}
+
+	// Test single upsert error handling.
+	err = repo.UpsertScan(ctx, rec)
+	if err == nil {
+		t.Error("Expected error when database is closed, got nil")
+	}
+
+	// Test batch upsert error handling.
+	err = repo.UpsertScans(ctx, []*repository.ScanRecord{rec})
+	if err == nil {
+		t.Error("Expected error in batch upsert when database is closed, got nil")
+	}
+}
+
+// TestSQLiteRepository_Constraints verifies that database-level constraints
+// (like NOT NULL) are enforced.
+func TestSQLiteRepository_Constraints(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	repo, err := NewSQLiteRepository(":memory:", logger)
+	if err != nil {
+		t.Fatalf("Failed to create repo: %v", err)
+	}
+	ctx := context.Background()
+
+	// Test NOT NULL constraint on Ip.
+	// Since we use the sql.DB directly here, we can force a NULL value that
+	// the Go struct wouldn't normally allow.
+	sqliteRepo := repo.(*Repository)
+	_, err = sqliteRepo.db.ExecContext(ctx, "INSERT INTO scans (ip, port, service, timestamp, response) VALUES (NULL, 80, 'HTTP', '2023-01-01', 'test')")
+	if err == nil {
+		t.Error("Expected error when inserting NULL Ip, got nil")
+	}
+}
+
+// TestSQLiteRepository_UpsertScans verifies that batch processing works
+// correctly for multiple records.
+func TestSQLiteRepository_UpsertScans(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	repo, err := NewSQLiteRepository(":memory:", logger)
+	if err != nil {
+		t.Fatalf("Failed to create repo: %v", err)
+	}
+
+	ctx := context.Background()
+
+	recs := []*repository.ScanRecord{
+		{
+			IP:          "1.1.1.1",
+			Port:        80,
+			Service:     "HTTP",
+			Timestamp:   time.Now(),
+			DataVersion: int(scanning.V2),
+			RawData:     &scanning.V2Data{ResponseStr: "one"},
+			Response:    "one",
+		},
+		{
+			IP:          "1.1.1.2",
+			Port:        443,
+			Service:     "HTTPS",
+			Timestamp:   time.Now(),
+			DataVersion: int(scanning.V2),
+			RawData:     &scanning.V2Data{ResponseStr: "two"},
+			Response:    "two",
+		},
+	}
+
+	if err := repo.UpsertScans(ctx, recs); err != nil {
+		t.Fatalf("UpsertScans failed: %v", err)
+	}
+
+	for _, wantRecord := range recs {
+		got, err := repo.GetScan(ctx, wantRecord.IP, wantRecord.Port, wantRecord.Service)
+		if err != nil {
+			t.Fatalf("GetScan failed for %s: %v", wantRecord.IP, err)
+		}
+		wantResponse := wantRecord.RawData.(*scanning.V2Data).ResponseStr
+		if got == nil || got.Response != wantResponse {
+			t.Errorf("Expected response %s for %s, got %v", wantResponse, wantRecord.IP, got)
+		}
+	}
+}
+
+// TestSQLiteRepository_Versions ensures that the repository correctly handles
+// both V1 (base64) and V2 (plain text) data formats.
+func TestSQLiteRepository_Versions(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	repo, err := NewSQLiteRepository(":memory:", logger)
+	if err != nil {
+		t.Fatalf("Failed to create repo: %v", err)
+	}
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		record   *repository.ScanRecord
+		expected string
+	}{
+		{
+			name: "V1 base64: 'hello world'",
+			record: &repository.ScanRecord{
+				IP:          "1.1.1.1",
+				Port:        80,
+				Service:     "HTTP",
+				Timestamp:   time.Now(),
+				DataVersion: int(scanning.V1),
+				RawData:     &scanning.V1Data{ResponseBytesUtf8: []byte("hello world")},
+				Response:    "hello world",
+			},
+			expected: "hello world",
+		},
+		{
+			name: "V2 plain text: 'hello world'",
+			record: &repository.ScanRecord{
+				IP:          "1.1.1.2",
+				Port:        80,
+				Service:     "HTTP",
+				Timestamp:   time.Now(),
+				DataVersion: int(scanning.V2),
+				RawData:     &scanning.V2Data{ResponseStr: "hello world"},
+				Response:    "hello world",
+			},
+			expected: "hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := repo.UpsertScan(ctx, tt.record); err != nil {
+				t.Fatalf("UpsertScan failed: %v", err)
+			}
+			got, err := repo.GetScan(ctx, tt.record.IP, tt.record.Port, tt.record.Service)
+			if err != nil {
+				t.Fatalf("GetScan failed: %v", err)
+			}
+			if got.Response != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, got.Response)
+			}
+		})
+	}
+}

--- a/pkg/scanning/service.go
+++ b/pkg/scanning/service.go
@@ -1,0 +1,10 @@
+package scanning
+
+import (
+	"context"
+)
+
+type Service interface {
+	ProcessScan(ctx context.Context, scan *Scan) error
+	ProcessScans(ctx context.Context, scans []*Scan) error
+}

--- a/pkg/service/scan_service.go
+++ b/pkg/service/scan_service.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/censys/scan-takehome/pkg/repository"
+	"github.com/censys/scan-takehome/pkg/scanning"
+)
+
+type scanService struct {
+	repo   repository.Repository
+	logger *log.Logger
+}
+
+func NewScanService(repo repository.Repository, logger *log.Logger) scanning.Service {
+	return &scanService{repo: repo, logger: logger}
+}
+
+func (s *scanService) ProcessScan(ctx context.Context, scan *scanning.Scan) error {
+	return s.repo.UpsertScan(ctx, s.toRecord(scan))
+}
+
+func (s *scanService) ProcessScans(ctx context.Context, scans []*scanning.Scan) error {
+	records := make([]*repository.ScanRecord, len(scans))
+	for i, scan := range scans {
+		records[i] = s.toRecord(scan)
+	}
+	return s.repo.UpsertScans(ctx, records)
+}
+
+func (s *scanService) toRecord(scan *scanning.Scan) *repository.ScanRecord {
+	var resp string
+	switch scan.DataVersion {
+	case scanning.V1:
+		if v1, ok := scan.Data.(*scanning.V1Data); ok {
+			resp = string(v1.ResponseBytesUtf8)
+		}
+	case scanning.V2:
+		if v2, ok := scan.Data.(*scanning.V2Data); ok {
+			resp = v2.ResponseStr
+		}
+	}
+
+	return &repository.ScanRecord{
+		IP:          scan.Ip,
+		Port:        scan.Port,
+		Service:     scan.Service,
+		Timestamp:   time.Unix(scan.Timestamp, 0),
+		DataVersion: int(scan.DataVersion),
+		RawData:     scan.Data,
+		Response:    resp,
+	}
+}

--- a/pkg/service/scan_service_test.go
+++ b/pkg/service/scan_service_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+	"io"
+	"log"
+	"testing"
+
+	"github.com/censys/scan-takehome/pkg/repository"
+	"github.com/censys/scan-takehome/pkg/scanning"
+)
+
+type mockRepository struct {
+	upsertFunc func(ctx context.Context, record *repository.ScanRecord) error
+}
+
+func (m *mockRepository) UpsertScan(ctx context.Context, record *repository.ScanRecord) error {
+	return m.upsertFunc(ctx, record)
+}
+
+func (m *mockRepository) UpsertScans(ctx context.Context, records []*repository.ScanRecord) error {
+	for _, r := range records {
+		if err := m.upsertFunc(ctx, r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *mockRepository) GetScan(ctx context.Context, ip string, port uint32, service string) (*repository.ScanRecord, error) {
+	return nil, nil
+}
+
+func TestProcessScan(t *testing.T) {
+	ctx := context.Background()
+	var capturedRecord *repository.ScanRecord
+
+	repo := &mockRepository{
+		upsertFunc: func(ctx context.Context, record *repository.ScanRecord) error {
+			capturedRecord = record
+			return nil
+		},
+	}
+
+	logger := log.New(io.Discard, "", 0)
+	svc := NewScanService(repo, logger)
+
+	scan := &scanning.Scan{
+		Ip:          "1.2.3.4",
+		Port:        80,
+		Service:     "HTTP",
+		Timestamp:   1234567890,
+		DataVersion: scanning.V2,
+		Data:        &scanning.V2Data{ResponseStr: "hello"},
+	}
+
+	err := svc.ProcessScan(ctx, scan)
+	if err != nil {
+		t.Fatalf("ProcessScan failed: %v", err)
+	}
+
+	if capturedRecord == nil {
+		t.Fatal("Expected record to be captured by mock repository")
+	}
+
+	if capturedRecord.IP != "1.2.3.4" {
+		t.Errorf("Expected Ip 1.2.3.4, got %s", capturedRecord.IP)
+	}
+
+	if capturedRecord.Timestamp.Unix() != 1234567890 {
+		t.Errorf("Expected timestamp 1234567890, got %d", capturedRecord.Timestamp.Unix())
+	}
+
+	if capturedRecord.DataVersion != int(scanning.V2) {
+		t.Errorf("Expected Version V2, got %d", capturedRecord.DataVersion)
+	}
+
+	if v2, ok := capturedRecord.RawData.(*scanning.V2Data); !ok || v2.ResponseStr != "hello" {
+		t.Errorf("Expected RawData to be V2 with 'hello', got %v", capturedRecord.RawData)
+	}
+
+	if capturedRecord.Response != "hello" {
+		t.Errorf("Expected Response 'hello', got %s", capturedRecord.Response)
+	}
+}
+
+func TestProcessScan_V1(t *testing.T) {
+	ctx := context.Background()
+	var capturedRecord *repository.ScanRecord
+
+	repo := &mockRepository{
+		upsertFunc: func(ctx context.Context, record *repository.ScanRecord) error {
+			capturedRecord = record
+			return nil
+		},
+	}
+
+	logger := log.New(io.Discard, "", 0)
+	svc := NewScanService(repo, logger)
+
+	scan := &scanning.Scan{
+		Ip:          "1.2.3.4",
+		Port:        80,
+		Service:     "HTTP",
+		Timestamp:   1234567890,
+		DataVersion: scanning.V1,
+		Data:        &scanning.V1Data{ResponseBytesUtf8: []byte("hello v1")},
+	}
+
+	err := svc.ProcessScan(ctx, scan)
+	if err != nil {
+		t.Fatalf("ProcessScan failed: %v", err)
+	}
+
+	if capturedRecord.Response != "hello v1" {
+		t.Errorf("Expected Response 'hello v1', got %s", capturedRecord.Response)
+	}
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,0 +1,186 @@
+// Package e2e provides end-to-end tests for the entire mini-scan system.
+// These tests verify the full data flow: from Pub/Sub message publishing to
+// database persistence, ensuring all components (processor, service, repository)
+// work together correctly.
+package e2e
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/censys/scan-takehome/pkg/repository/sqlite"
+	"github.com/censys/scan-takehome/pkg/scanning"
+	"github.com/censys/scan-takehome/pkg/service"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// testCase defines the parameters for a single E2E test run.
+type testCase struct {
+	name        string        // Description of the test
+	numMessages int           // Number of scan results to simulate
+	timeout     time.Duration // Maximum time to wait for processing to complete
+}
+
+// TestEndToEnd executes a series of table-driven end-to-end tests.
+func TestEndToEnd(t *testing.T) {
+	projectID := "test-project"
+	topicID := "scan-topic-e2e"
+	subscriptionID := "scan-sub-e2e"
+
+	// Ensure PubSub emulator is used. The emulator is expected to be running
+	// (usually started by the Makefile).
+	if os.Getenv("PUBSUB_EMULATOR_HOST") == "" {
+		os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:8085")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := pubsub.NewClient(ctx, projectID)
+	if err != nil {
+		t.Fatalf("Failed to create pubsub client: %v", err)
+	}
+	defer client.Close()
+
+	// Setup Topic: create it if it doesn't exist.
+	topic := client.Topic(topicID)
+	exists, err := topic.Exists(ctx)
+	if err != nil {
+		t.Fatalf("Failed to check topic: %v", err)
+	}
+	if !exists {
+		topic, err = client.CreateTopic(ctx, topicID)
+		if err != nil {
+			t.Fatalf("Failed to create topic: %v", err)
+		}
+	}
+
+	// Setup Subscription: create it if it doesn't exist.
+	sub := client.Subscription(subscriptionID)
+	exists, err = sub.Exists(ctx)
+	if err != nil {
+		t.Fatalf("Failed to check subscription: %v", err)
+	}
+	if !exists {
+		_, err = client.CreateSubscription(ctx, subscriptionID, pubsub.SubscriptionConfig{
+			Topic: topic,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create subscription: %v", err)
+		}
+	}
+
+	testCases := []testCase{
+		{
+			name:        "Process 10 messages",
+			numMessages: 10,
+			timeout:     10 * time.Second,
+		},
+		{
+			name:        "Process 50 messages",
+			numMessages: 50,
+			timeout:     10 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a temporary database file for each test case to ensure isolation.
+			tmpDB := filepath.Join(t.TempDir(), "test.db")
+
+			// Start the Processor logic in a background goroutine.
+			procCtx, procCancel := context.WithCancel(ctx)
+			defer procCancel()
+
+			go func() {
+				// We use a simplified version of the processor logic for testing.
+				runProcessor(procCtx, projectID, subscriptionID, tmpDB)
+			}()
+
+			// Give the processor a moment to initialize and start its receive loop.
+			time.Sleep(1 * time.Second)
+
+			// 2. Publish messages (simulating the 'scanner' application).
+			var sentCount int
+			for i := 0; i < tc.numMessages; i++ {
+				scan := &scanning.Scan{
+					Ip:          fmt.Sprintf("192.168.1.%d", i),
+					Port:        uint32(8080 + i),
+					Service:     "HTTP",
+					Timestamp:   time.Now().Unix(),
+					DataVersion: scanning.V2,
+					Data:        &scanning.V2Data{ResponseStr: fmt.Sprintf("resp-%d", i)},
+				}
+				data, _ := json.Marshal(scan)
+				res := topic.Publish(ctx, &pubsub.Message{Data: data})
+				_, err := res.Get(ctx)
+				if err == nil {
+					sentCount++
+				}
+			}
+			t.Logf("Sent %d messages", sentCount)
+
+			// 3. Wait and verify: poll the database until all messages are stored or timeout occurs.
+			db, err := sql.Open("sqlite3", tmpDB)
+			if err != nil {
+				t.Fatalf("Failed to open database: %v", err)
+			}
+			defer db.Close()
+
+			deadline := time.Now().Add(tc.timeout)
+			var count int
+			for time.Now().Before(deadline) {
+				// Query the database to count the number of successfully persisted scans.
+				_ = db.QueryRow("SELECT COUNT(*) FROM scans").Scan(&count)
+				if count >= tc.numMessages {
+					break
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
+
+			// Final verification: did we store exactly as many as we sent?
+			if count != sentCount {
+				t.Errorf("Expected %d records (sent), got %d (stored)", sentCount, count)
+			} else {
+				t.Logf("Successfully processed %d messages and verified in DB", count)
+			}
+		})
+	}
+}
+
+// runProcessor is a helper function that spins up a minimal version of the
+// processor application for testing purposes. It enables end-to-end verification
+// without needing to run a separate binary.
+func runProcessor(ctx context.Context, projectID, subscriptionID, dbPath string) {
+	// Initialize real dependencies.
+	logger := log.New(io.Discard, "", 0)
+	repo, _ := sqlite.NewSQLiteRepository(dbPath, logger)
+	svc := service.NewScanService(repo, logger)
+	client, _ := pubsub.NewClient(ctx, projectID)
+	defer client.Close()
+
+	// Simplified receive loop for E2E testing.
+	sub := client.Subscription(subscriptionID)
+	_ = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+		var scan scanning.Scan
+		if err := json.Unmarshal(msg.Data, &scan); err == nil {
+			// Process and then Ack to maintain at-least-once semantics.
+			if err := svc.ProcessScan(ctx, &scan); err == nil {
+				msg.Ack()
+			} else {
+				msg.Nack()
+			}
+		} else {
+			msg.Ack() // Ack malformed JSON to avoid loops.
+		}
+	})
+}


### PR DESCRIPTION
Add initial implementation of processor, repository, tests, and supporting components

- Introduced the processor to consume and process scan results from Pub/Sub and store them in SQLite.
- Added a repository layer for data persistence with conflict handling for out-of-order messages.
- Implemented e2e tests and unit tests for validation.
- Added a Makefile to streamline build and test workflows.